### PR TITLE
Guessing required should look for a column default

### DIFF
--- a/Form/DoctrineOrmTypeGuesser.php
+++ b/Form/DoctrineOrmTypeGuesser.php
@@ -95,7 +95,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 
         // Check whether the field exists and is nullable or not
         if ($classMetadata->hasField($property)) {
-            if (!$classMetadata->isNullable($property)) {
+            if (!$classMetadata->isNullable($property) && !array_key_exists('default', $classMetadata->getFieldMapping($property)['options'])) {
                 return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
             }
 


### PR DESCRIPTION
When inferring whether a property should be required or not, the logic makes more sense as:

* is not nullable and has no default = required
* is not nullable and has a default = not required
* is nullable and has no default = not required
* is nullable and has a default = not required

This makes sense for things like:

* State fields (integer) that default to 0 and cannot be null